### PR TITLE
Feature/slug (#27)

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -38,7 +38,7 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
         run: |
-          bin/rails db:setup
+          bin/rails db:create db:migrate
 
       - name: Compile code
         run: bin/rails webpacker:compile

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
 
   gem 'factory_bot_rails'
 
-  gem 'lorem_ipsum_amet'
+  gem 'literate_randomizer'
 
   gem 'dotenv-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,10 +133,10 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    literate_randomizer (0.4.0)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lorem_ipsum_amet (0.6.2)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
@@ -294,7 +294,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   launchy (~> 2.5)
   listen (~> 3.3)
-  lorem_ipsum_amet
+  literate_randomizer
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+    rescue_from ActiveRecord::RecordNotFound do |_exception|
+      render file: 'public/404', status: :not_found
+    end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -20,7 +20,7 @@ class ArticlesController < ApplicationController
     end
 
     def show
-        @article = Article.find(permittedParam[:id])
+        @article = Article.sluggable.find(permittedParam[:id])
     end
 
     def new
@@ -38,11 +38,11 @@ class ArticlesController < ApplicationController
     end
 
     def edit
-        @article = Article.find(permittedParam[:id])
+        @article = Article.sluggable.find(permittedParam[:id])
     end
 
     def update
-        @article = Article.find(permittedParam[:id])
+        @article = Article.sluggable.find(permittedParam[:id])
 
         if @article.update(article_params)
             redirect_to @article 
@@ -52,7 +52,7 @@ class ArticlesController < ApplicationController
     end
 
     def destroy
-        @article = Article.find(permittedParam[:id])
+        @article = Article.sluggable.find(permittedParam[:id])
         @article.destroy
 
         redirect_to articles_path, status: :see_other

--- a/app/javascript/components/articles/HomePage.jsx
+++ b/app/javascript/components/articles/HomePage.jsx
@@ -8,7 +8,7 @@ import ErrorBlock from "../ErrorBlock";
 const HomePage = (props) => {
 
   function createArticle(item, index) {
-    const link = `/articles/${item.id}`;
+    const link = `/articles/${item.slug}`;
 
     return (
         <div

--- a/app/lib/sluggable.rb
+++ b/app/lib/sluggable.rb
@@ -1,0 +1,56 @@
+module Sluggable
+    module Finder
+      # Finds a record using the given id.
+      #
+      # If the id is "unslug", it will call the original find method.
+      # If the id is a numeric string like '123' it will first look for a slug
+      # id matching '123' and then fall back to looking for a record with the
+      # numeric id '123'.
+      #
+      # if the id is a numeric string like '123-foo' it
+      # will only search by slug id and not fall back to the regular find method.
+      #
+      # @raise ActiveRecord::RecordNotFound
+      def find(*args)
+        id = args.first
+        return super if args.count != 1 || Helper.unslug?(id)
+        resource = resource_by_slug(id)
+        resource ? resource : super
+      end
+  
+      private
+  
+      def resource_by_slug(id)
+        resource = find_by(slug: id)
+        raise ActiveRecord::RecordNotFound unless resource
+        resource
+      end
+    end
+  
+    module Helper
+      class << self
+        # True if the id is definitely slug, false if definitely unslug
+        #
+        # An object is considered "definitely unslug" if its class is or
+        # inherits from ActiveRecord::Base, Array, Hash, NilClass, Numeric, or
+        # Symbol.
+        #
+        # An object is considered "definitely slug" if it responds to +to_i+,
+        # and its value when cast to an integer and then back to a string is
+        # different from its value when merely cast to a string:
+        #
+        #     slug?(123)          => false
+        #     slug?("123")        => false
+        #     slug?("abc123")     => true
+        def slug?(arg)
+          false if Integer(arg)
+        rescue ArgumentError, TypeError
+          true
+        end
+  
+        def unslug?(arg)
+          !slug?(arg)
+        end
+      end
+    end
+  end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,9 +1,19 @@
 class Article < ApplicationRecord
     validates :title, presence: true
     validates :body, presence: true
+    
+    after_validation :set_slug, only: [:create, :update]
 
+    def self.sluggable
+        all.extending(Sluggable::Finder)
+    end
+
+    def to_param
+        return nil unless persisted?
+        slug
+    end
+  
     def self.last_page(limit: 10)
-
         if limit != 0 
             (self.count / limit.to_f).ceil
         else
@@ -19,7 +29,13 @@ class Article < ApplicationRecord
         if limit == 0
             limit = Article.count
         end
-        
+      
         order_data.limit(limit).offset(limit * (page - 1))
+    end
+  
+  private
+
+    def set_slug
+        self.slug = title.to_s.parameterize
     end
 end

--- a/db/migrate/20220124190257_create_articles.rb
+++ b/db/migrate/20220124190257_create_articles.rb
@@ -3,6 +3,7 @@ class CreateArticles < ActiveRecord::Migration[6.1]
     create_table :articles do |t|
       t.string :title
       t.text :body
+      t.string :slug
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 2022_01_24_190257) do
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.text "body"
+    t.string "slug"
+    
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-# 100.times do |i|
-#     Article.create(
-#         title: "Article #{i + 1}",
-#         body: LoremIpsum.w(50),
-#     )
-# end
+100.times do
+    Article.create(
+        title: LiterateRandomizer.sentence(:words => 5),
+        body: LiterateRandomizer.paragraph,
+    )
+end


### PR DESCRIPTION
* Adds rescue_from to render 404 page if article not found

* Extends database's find method to search for article using slug

* Adds slug column to schema and migration

* Creates slug from title. Overrides .to_param and .all to incorporate slug

Co-authored-by: Josiah <josiah.pilon@gmail.com>